### PR TITLE
Simplified the remote ipc/cluster/echo benchmark scripts.

### DIFF
--- a/scripts/aeron/remote-archive-replay-mdc-benchmarks
+++ b/scripts/aeron/remote-archive-replay-mdc-benchmarks
@@ -230,23 +230,38 @@ function start_replay_node()
   local archive_response_channel_var=NODE${node_id}_ARCHIVE_RESPONSE_CHANNEL
   local replay_channel_var=NODE${node_id}_REPLAY_CHANNEL
   echo "
-    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"replay-node-media-driver-${node_id}\" \
-    ; $(kill_java_process "${node_class_name}") \
-    ; ${server_driver} \
-    && export JVM_OPTS=\"\
-    -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout} \
-    -Dio.aeron.benchmarks.output.directory=${output_dir} \
-    -Dio.aeron.benchmarks.aeron.replay.channel=${!replay_channel_var} \
-    -Dio.aeron.benchmarks.aeron.record.channel=${RECORD_CHANNEL} \
-    -Dio.aeron.benchmarks.aeron.source.channel=${SOURCE_CHANNEL} \
-    -Dio.aeron.benchmarks.aeron.receiver.index=${node_id} \
-    -Daeron.archive.control.channel=${ARCHIVE_CONTROL_CHANNEL} \
-    -Daeron.archive.control.response.channel=${!archive_response_channel_var} \
-    ${!extra_properties_var:-}\" PROCESS_FILE_NAME=\"replay-node-${node_id}\" \
-    && numactl --membind=${!cpu_node_var} --cpunodebind=${!cpu_node_var} --physcpubind=\"${!non_isolated_cpu_cores_var}\" ${!benchmarks_path_var}/scripts/aeron/replay-node & \
-    $(await_java_process_start "${node_class_name}") \
-    ; $(pin_thread "\${pid}" "replay-${node_id}" "${!replay_cpu_var}") \
-    && tail --pid=\$! -f /dev/null"
+    set -e
+    export JAVA_HOME=\"${!java_home_var}\"
+    export PROCESS_FILE_NAME=\"replay-node-media-driver-${node_id}\"
+
+    $(kill_java_process "${node_class_name}")
+
+    ${server_driver}
+
+    export JVM_OPTS=\"\
+      -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout} \
+      -Dio.aeron.benchmarks.output.directory=${output_dir} \
+      -Dio.aeron.benchmarks.aeron.replay.channel=${!replay_channel_var} \
+      -Dio.aeron.benchmarks.aeron.record.channel=${RECORD_CHANNEL} \
+      -Dio.aeron.benchmarks.aeron.source.channel=${SOURCE_CHANNEL} \
+      -Dio.aeron.benchmarks.aeron.receiver.index=${node_id} \
+      -Daeron.archive.control.channel=${ARCHIVE_CONTROL_CHANNEL} \
+      -Daeron.archive.control.response.channel=${!archive_response_channel_var} \
+      ${!extra_properties_var:-}\"
+
+     export PROCESS_FILE_NAME=\"replay-node-${node_id}\"
+
+     numactl --membind=${!cpu_node_var} \
+             --cpunodebind=${!cpu_node_var} \
+             --physcpubind=\"${!non_isolated_cpu_cores_var}\" \
+             ${!benchmarks_path_var}/scripts/aeron/replay-node &
+
+     $(await_java_process_start "${node_class_name}")
+
+     $(pin_thread "\${pid}" "replay-${node_id}" "${!replay_cpu_var}")
+
+     tail --pid=\$! -f /dev/null
+   "
 }
 
 scripts_path="benchmarks_path_var/scripts/aeron"
@@ -408,60 +423,95 @@ do
 
             output_dir="${output_dir_prefix}/${test}_length=${messageLength}_rate=${messageRate}/run-${run}"
 
-            start_client="export JVM_OPTS=\"\
-            -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout}\
-            -Dio.aeron.benchmarks.warmup.iterations=${warmupIterations}\
-            -Dio.aeron.benchmarks.warmup.message.rate=${warmupMessageRate}\
-            -Dio.aeron.benchmarks.iterations=${iterations}\
-            -Dio.aeron.benchmarks.message.rate=${messageRate# }\
-            -Dio.aeron.benchmarks.batch.size=${burstSize# }\
-            -Dio.aeron.benchmarks.message.length=${messageLength# }\
-            -Dio.aeron.benchmarks.output.file=${test}\
-            -Dio.aeron.benchmarks.track.history=${TRACK_HISTORY:-false}\
-            -Dio.aeron.benchmarks.report.progress=${REPORT_PROGRESS:-false}\
-            -Dio.aeron.benchmarks.output.directory=${CLIENT_BENCHMARKS_PATH}/${output_dir}\
-            -Dio.aeron.benchmarks.aeron.destination.channel=${DESTINATION_CHANNEL}\
-            -Dio.aeron.benchmarks.aeron.source.channel=${SOURCE_CHANNEL}\
-            -Dio.aeron.benchmarks.aeron.receiver.count=${RECEIVER_COUNT}\
-            ${CLIENT_EXTRA_PROPERTIES:-}\"\
-            && export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"client-media-driver\"\
-            ; $(kill_java_process "${client_class_name}")\
-            ; ${client_driver}\
-            ; export PROCESS_FILE_NAME=\"echo-client\"\
-            && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/echo-client & \
-            $(await_java_process_start "${client_class_name}")\
-            ; $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")\
-            && tail --pid=\$! -f /dev/null; kill -9 \${media_driver_pid}; wait"
+            start_client="set -e
+              export JVM_OPTS=\"\
+                -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout} \
+                -Dio.aeron.benchmarks.warmup.iterations=${warmupIterations} \
+                -Dio.aeron.benchmarks.warmup.message.rate=${warmupMessageRate} \
+                -Dio.aeron.benchmarks.iterations=${iterations} \
+                -Dio.aeron.benchmarks.message.rate=${messageRate# } \
+                -Dio.aeron.benchmarks.batch.size=${burstSize# } \
+                -Dio.aeron.benchmarks.message.length=${messageLength# } \
+                -Dio.aeron.benchmarks.output.file=${test} \
+                -Dio.aeron.benchmarks.track.history=${TRACK_HISTORY:-false} \
+                -Dio.aeron.benchmarks.report.progress=${REPORT_PROGRESS:-false} \
+                -Dio.aeron.benchmarks.output.directory=${CLIENT_BENCHMARKS_PATH}/${output_dir} \
+                -Dio.aeron.benchmarks.aeron.destination.channel=${DESTINATION_CHANNEL} \
+                -Dio.aeron.benchmarks.aeron.source.channel=${SOURCE_CHANNEL} \
+                -Dio.aeron.benchmarks.aeron.receiver.count=${RECEIVER_COUNT} \
+                ${CLIENT_EXTRA_PROPERTIES:-}\"
 
-            start_server="export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"archive-node-media-driver\"\
-            ; $(kill_java_process "${server_class_name}") \
-            ; rm -rf ${ARCHIVE_DIR} \
-            ; sync; echo 3 | sudo tee /proc/sys/vm/drop_caches; sudo fstrim --all \
-            ; ${server_driver} \
-            && export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"archive-node\" \
-            JVM_OPTS=\"\
-            -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout}\
-            -Dio.aeron.benchmarks.output.directory=${SERVER_BENCHMARKS_PATH}/${output_dir} \
-            -Dio.aeron.benchmarks.aeron.destination.channel=${DESTINATION_CHANNEL} \
-            -Dio.aeron.benchmarks.aeron.record.channel=${RECORD_CHANNEL} \
-            -Daeron.archive.control.channel=${ARCHIVE_CONTROL_CHANNEL} \
-            -Daeron.archive.control.response.channel=${ARCHIVE_RESPONSE_CHANNEL} \
-            -Daeron.archive.replication.channel=${ARCHIVE_REPLICATION_CHANNEL} \
-            -Daeron.archive.id=179 \
-            -Daeron.archive.dir=${ARCHIVE_DIR} \
-            -Daeron.archive.mark.file.dir=/dev/shm/aeron \
-            -Daeron.archive.file.sync.level=${fsync} \
-            -Daeron.archive.catalog.file.sync.level=${fsync} \
-            -Daeron.archive.max.concurrent.replays=$((2 * RECEIVER_COUNT)) \
-            -Daeron.archive.max.concurrent.recordings=$((2 * RECEIVER_COUNT)) \
-            -Daeron.archive.recording.events.enabled=false\" \
-            ; numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} --physcpubind=\"${SERVER_NON_ISOLATED_CPU_CORES}\" ${SERVER_BENCHMARKS_PATH}/scripts/aeron/archive-node & \
-            $(await_java_process_start "${server_class_name}") \
-            ; $(pin_thread "\${pid}" "archive-recorde" "${SERVER_ARCHIVE_RECORDER_CPU_CORE}") \
-            ; $(pin_thread "\${pid}" "archive-replaye" "${SERVER_ARCHIVE_REPLAYER_CPU_CORE}") \
-            ; $(pin_thread "\${pid}" "archive-conduct" "${SERVER_ARCHIVE_CONDUCTOR_CPU_CORE}") \
-            ; $(pin_thread "\${pid}" "archive-node" "${SERVER_ARCHIVE_NODE_CPU_CORE}") \
-            && tail --pid=\$! -f /dev/null"
+              export JAVA_HOME=\"${CLIENT_JAVA_HOME}\"
+              export PROCESS_FILE_NAME=\"client-media-driver\"
+
+              $(kill_java_process "${client_class_name}")
+
+              ${client_driver}
+
+              export PROCESS_FILE_NAME=\"echo-client\"
+
+              numactl --membind=${CLIENT_CPU_NODE} \
+                      --cpunodebind=${CLIENT_CPU_NODE} \
+                      --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" \
+                      ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/echo-client &
+
+              $(await_java_process_start "${client_class_name}")
+
+              $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")
+
+              tail --pid=\$! -f /dev/null
+
+              kill -9 \${media_driver_pid}
+              wait
+              "
+
+          start_server="set -e
+            export JAVA_HOME=\"${SERVER_JAVA_HOME}\"
+            export PROCESS_FILE_NAME=\"archive-node-media-driver\"
+
+            $(kill_java_process "${server_class_name}")
+
+            rm -rf ${ARCHIVE_DIR}
+
+            sync
+            echo 3 | sudo tee /proc/sys/vm/drop_caches
+            sudo fstrim --all
+
+            ${server_driver}
+
+            export JAVA_HOME=\"${SERVER_JAVA_HOME}\"
+            export PROCESS_FILE_NAME=\"archive-node\"
+            export JVM_OPTS=\"\
+              -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout} \
+              -Dio.aeron.benchmarks.output.directory=${SERVER_BENCHMARKS_PATH}/${output_dir} \
+              -Dio.aeron.benchmarks.aeron.destination.channel=${DESTINATION_CHANNEL} \
+              -Dio.aeron.benchmarks.aeron.record.channel=${RECORD_CHANNEL} \
+              -Daeron.archive.control.channel=${ARCHIVE_CONTROL_CHANNEL} \
+              -Daeron.archive.control.response.channel=${ARCHIVE_RESPONSE_CHANNEL} \
+              -Daeron.archive.replication.channel=${ARCHIVE_REPLICATION_CHANNEL} \
+              -Daeron.archive.id=179 \
+              -Daeron.archive.dir=${ARCHIVE_DIR} \
+              -Daeron.archive.mark.file.dir=/dev/shm/aeron \
+              -Daeron.archive.file.sync.level=${fsync} \
+              -Daeron.archive.catalog.file.sync.level=${fsync} \
+              -Daeron.archive.max.concurrent.replays=$((2 * RECEIVER_COUNT)) \
+              -Daeron.archive.max.concurrent.recordings=$((2 * RECEIVER_COUNT)) \
+              -Daeron.archive.recording.events.enabled=false\"
+
+            numactl --membind=${SERVER_CPU_NODE} \
+                    --cpunodebind=${SERVER_CPU_NODE} \
+                    --physcpubind=\"${SERVER_NON_ISOLATED_CPU_CORES}\" \
+                    ${SERVER_BENCHMARKS_PATH}/scripts/aeron/archive-node &
+
+            $(await_java_process_start "${server_class_name}")
+
+            $(pin_thread "\${pid}" "archive-recorde" "${SERVER_ARCHIVE_RECORDER_CPU_CORE}")
+            $(pin_thread "\${pid}" "archive-replaye" "${SERVER_ARCHIVE_REPLAYER_CPU_CORE}")
+            $(pin_thread "\${pid}" "archive-conduct" "${SERVER_ARCHIVE_CONDUCTOR_CPU_CORE}")
+            $(pin_thread "\${pid}" "archive-node" "${SERVER_ARCHIVE_NODE_CPU_CORE}")
+
+            tail --pid=\$! -f /dev/null
+            "
 
             stop_server="$(stop_java_process "${server_class_name}"); $(stop_media_driver)"
 

--- a/scripts/aeron/remote-cluster-benchmarks
+++ b/scripts/aeron/remote-cluster-benchmarks
@@ -234,14 +234,23 @@ function start_cluster_node()
   local consensus_module_cpu_var=NODE${node_id}_CONSENSUS_MODULE_CPU_CORE
   local clustered_service_cpu_var=NODE${node_id}_CLUSTERED_SERVICE_CPU_CORE
   local extra_properties_var=NODE${node_id}_EXTRA_PROPERTIES
-  echo "
-    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"cluster-node-${node_id}-media-driver\" \
-    ; $(kill_java_process "${cluster_node_class_name}") \
-    ; rm -rf \"${!cluster_dir_var}\" \
-    ; rm -rf \"${!archive_dir_var}\" \
-    ; sync; echo 3 | sudo tee /proc/sys/vm/drop_caches; fstrim --all \
-    ; ${server_driver} \
-    && export JVM_OPTS=\"\
+  echo "set -e
+
+    export JAVA_HOME=\"${!java_home_var}\"
+    export PROCESS_FILE_NAME=\"cluster-node-${node_id}-media-driver\"
+
+    $(kill_java_process "${cluster_node_class_name}")
+
+    rm -rf \"${!cluster_dir_var}\"
+    rm -rf \"${!archive_dir_var}\"
+
+    sync
+    echo 3 | sudo tee /proc/sys/vm/drop_caches
+    fstrim --all
+
+    ${server_driver}
+
+    export JVM_OPTS=\"\
     -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout} \
     -Daeron.cluster.dir=${!cluster_dir_var} \
     -Daeron.cluster.idle.strategy=noop \
@@ -267,15 +276,24 @@ function start_cluster_node()
     -Daeron.archive.control.response.stream.id=120 \
     -Dio.aeron.benchmarks.aeron.cluster.service=${cluster_service} \
     -Dio.aeron.benchmarks.output.directory=${output_dir} \
-    ${!extra_properties_var:-}\" PROCESS_FILE_NAME=\"cluster-node-${node_id}\" \
-    && numactl --membind=${!cpu_node_var} --cpunodebind=${!cpu_node_var} --physcpubind=\"${!non_isolated_cpu_cores_var}\" ${!benchmarks_path_var}/scripts/aeron/cluster-node & \
-    $(await_java_process_start "${cluster_node_class_name}") \
-    ; $(pin_thread "\${pid}" "archive-recorde" "${!archive_recorder_cpu_var}") \
-    ; $(pin_thread "\${pid}" "archive-replaye" "${!archive_replayer_cpu_var}") \
-    ; $(pin_thread "\${pid}" "archive-conduct" "${!archive_conductor_cpu_var}") \
-    ; $(pin_thread "\${pid}" "consensus-modul" "${!consensus_module_cpu_var}") \
-    ; $(pin_thread "\${pid}" "echo-service" "${!clustered_service_cpu_var}") \
-    && tail --pid=\$! -f /dev/null"
+    ${!extra_properties_var:-}\"
+
+    export PROCESS_FILE_NAME=\"cluster-node-${node_id}\"
+
+    numactl --membind=${!cpu_node_var} --cpunodebind=${!cpu_node_var} \
+      --physcpubind=\"${!non_isolated_cpu_cores_var}\" \
+      ${!benchmarks_path_var}/scripts/aeron/cluster-node &
+
+    $(await_java_process_start "${cluster_node_class_name}")
+
+    pid=\${pid}
+    $(pin_thread "\${pid}" "archive-recorde" "${!archive_recorder_cpu_var}")
+    $(pin_thread "\${pid}" "archive-replaye" "${!archive_replayer_cpu_var}")
+    $(pin_thread "\${pid}" "archive-conduct" "${!archive_conductor_cpu_var}")
+    $(pin_thread "\${pid}" "consensus-modul" "${!consensus_module_cpu_var}")
+    $(pin_thread "\${pid}" "echo-service" "${!clustered_service_cpu_var}")
+
+    tail --pid=\$! -f /dev/null"
 }
 
 function start_cluster_backup_node()
@@ -301,14 +319,22 @@ function start_cluster_backup_node()
   local archive_replayer_cpu_var=BACKUP_NODE${node_id}_ARCHIVE_REPLAYER_CPU_CORE
   local archive_conductor_cpu_var=BACKUP_NODE${node_id}_ARCHIVE_CONDUCTOR_CPU_CORE
   local cluster_backup_cpu_var=BACKUP_NODE${node_id}_CLUSTER_BACKUP_CPU_CORE
-  echo "
-    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"cluster-backup-node-${node_id}-media-driver\" \
-    ; $(kill_java_process "${cluster_backup_node_class_name}") \
-    ; rm -rf \"${!cluster_dir_var}\" \
-    ; rm -rf \"${!archive_dir_var}\" \
-    ; sync; echo 3 | sudo tee /proc/sys/vm/drop_caches; fstrim --all \
-    ; ${server_driver} \
-    && export JVM_OPTS=\"\
+  echo "set -e
+    export JAVA_HOME=\"${!java_home_var}\"
+    export PROCESS_FILE_NAME=\"cluster-backup-node-${node_id}-media-driver\"
+
+    $(kill_java_process "${cluster_backup_node_class_name}")
+
+    rm -rf \"${!cluster_dir_var}\"
+    rm -rf \"${!archive_dir_var}\"
+
+    sync
+    echo 3 | sudo tee /proc/sys/vm/drop_caches
+    fstrim --all
+
+    ${server_driver}
+
+    export JVM_OPTS=\"\
     -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout} \
     -Daeron.cluster.dir=${!cluster_dir_var} \
     -Daeron.cluster.id=${CLUSTER_ID} \
@@ -330,14 +356,23 @@ function start_cluster_backup_node()
     -Daeron.archive.local.control.stream.id=110 \
     -Daeron.archive.control.stream.id=110 \
     -Daeron.archive.control.response.stream.id=120 \
-    -Dio.aeron.benchmarks.output.directory=${output_dir}\" PROCESS_FILE_NAME=\"cluster-backup-node-${node_id}\"\
-    && numactl --membind=${!cpu_node_var} --cpunodebind=${!cpu_node_var} --physcpubind=\"${!non_isolated_cpu_cores_var}\" ${!benchmarks_path_var}/scripts/aeron/cluster-backup-node & \
-    $(await_java_process_start "${cluster_backup_node_class_name}") \
-    ; $(pin_thread "\${pid}" "archive-recorde" "${!archive_recorder_cpu_var}") \
-    ; $(pin_thread "\${pid}" "archive-replaye" "${!archive_replayer_cpu_var}") \
-    ; $(pin_thread "\${pid}" "archive-conduct" "${!archive_conductor_cpu_var}") \
-    ; $(pin_thread "\${pid}" "cluster-backup" "${!cluster_backup_cpu_var}") \
-    && tail --pid=\$! -f /dev/null"
+    -Dio.aeron.benchmarks.output.directory=${output_dir}\"
+
+    export PROCESS_FILE_NAME=\"cluster-backup-node-${node_id}\"
+
+    numactl --membind=${!cpu_node_var} --cpunodebind=${!cpu_node_var} \
+      --physcpubind=\"${!non_isolated_cpu_cores_var}\" \
+      ${!benchmarks_path_var}/scripts/aeron/cluster-backup-node &
+
+    $(await_java_process_start "${cluster_backup_node_class_name}")
+
+    pid=\${pid}
+    $(pin_thread "\${pid}" "archive-recorde" "${!archive_recorder_cpu_var}")
+    $(pin_thread "\${pid}" "archive-replaye" "${!archive_replayer_cpu_var}")
+    $(pin_thread "\${pid}" "archive-conduct" "${!archive_conductor_cpu_var}")
+    $(pin_thread "\${pid}" "cluster-backup" "${!cluster_backup_cpu_var}")
+
+    tail --pid=\$! -f /dev/null"
 }
 
 scripts_path="benchmarks_path_var/scripts/aeron"
@@ -494,31 +529,47 @@ do
 
             output_dir="${output_dir_prefix}/${client_md}-vs-${server_md}_${context}_fsync=${fsync}_mtu=${mtu}_length=${messageLength}_rate=${messageRate}/run-${run}"
 
-            start_client="export JVM_OPTS=\"\
-            -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout}\
-            -Dio.aeron.benchmarks.warmup.iterations=${warmupIterations}\
-            -Dio.aeron.benchmarks.warmup.message.rate=${warmupMessageRate}\
-            -Dio.aeron.benchmarks.iterations=${iterations}\
-            -Dio.aeron.benchmarks.message.rate=${messageRate# }\
-            -Dio.aeron.benchmarks.batch.size=${burstSize# }\
-            -Dio.aeron.benchmarks.message.length=${messageLength# }\
-            -Dio.aeron.benchmarks.output.file=${test}\
-            -Dio.aeron.benchmarks.output.time.unit=${OUTPUT_TIME_UNIT:-MICROSECONDS}\
-            -Dio.aeron.benchmarks.track.history=${TRACK_HISTORY:-false}\
-            -Dio.aeron.benchmarks.report.progress=${REPORT_PROGRESS:-false}\
-            -Dio.aeron.benchmarks.output.directory=${CLIENT_BENCHMARKS_PATH}/${output_dir}\
-            -Daeron.cluster.ingress.channel=${CLIENT_INGRESS_CHANNEL}\
-            ${client_ingress_endpoints}\
-            -Daeron.cluster.egress.channel=${CLIENT_EGRESS_CHANNEL}\
-            -Daeron.cluster.message.timeout=300000000000\
-            ${CLIENT_EXTRA_PROPERTIES:-}\"\
-            && export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"cluster-client-media-driver\"\
-            ; $(kill_java_process "${client_class_name}")\
-            ; ${client_driver}\
-            && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/${client_script} & \
-            $(await_java_process_start "${client_class_name}")\
-            ; $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")\
-            && tail --pid=\$! -f /dev/null; kill -9 \${media_driver_pid}; wait"
+            start_client="set -e
+              export JVM_OPTS=\"\
+              -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout} \
+              -Dio.aeron.benchmarks.warmup.iterations=${warmupIterations} \
+              -Dio.aeron.benchmarks.warmup.message.rate=${warmupMessageRate} \
+              -Dio.aeron.benchmarks.iterations=${iterations} \
+              -Dio.aeron.benchmarks.message.rate=${messageRate# } \
+              -Dio.aeron.benchmarks.batch.size=${burstSize# } \
+              -Dio.aeron.benchmarks.message.length=${messageLength# } \
+              -Dio.aeron.benchmarks.output.file=${test} \
+              -Dio.aeron.benchmarks.output.time.unit=${OUTPUT_TIME_UNIT:-MICROSECONDS} \
+              -Dio.aeron.benchmarks.track.history=${TRACK_HISTORY:-false} \
+              -Dio.aeron.benchmarks.report.progress=${REPORT_PROGRESS:-false} \
+              -Dio.aeron.benchmarks.output.directory=${CLIENT_BENCHMARKS_PATH}/${output_dir} \
+              -Daeron.cluster.ingress.channel=${CLIENT_INGRESS_CHANNEL} \
+              ${client_ingress_endpoints} \
+              -Daeron.cluster.egress.channel=${CLIENT_EGRESS_CHANNEL} \
+              -Daeron.cluster.message.timeout=300000000000 \
+              ${CLIENT_EXTRA_PROPERTIES:-}\"
+
+              export JAVA_HOME=\"${CLIENT_JAVA_HOME}\"
+              export PROCESS_FILE_NAME=\"cluster-client-media-driver\"
+
+              $(kill_java_process "${client_class_name}")
+
+              ${client_driver}
+
+              numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} \
+                --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" \
+                ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/${client_script} &
+
+              $(await_java_process_start "${client_class_name}")
+
+              pid=\${pid}
+              $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")
+
+              tail --pid=\$! -f /dev/null
+
+              kill -9 \${media_driver_pid}
+              wait
+              "
 
             for (( n=0; n<CLUSTER_BACKUP_NODES; n++ ))
             do

--- a/scripts/aeron/remote-echo-benchmarks
+++ b/scripts/aeron/remote-echo-benchmarks
@@ -286,22 +286,46 @@ do
     client_class_name="io.aeron.benchmarks.LoadTestRig"
     server_class_name="io.aeron.benchmarks.aeron.EchoNode"
 
-    start_client="\
-    export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"echo-client-media-driver\" \
-    ; $(kill_java_process "${client_class_name}") \
-    ; ${client_driver} \
-    && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/echo-client & \
-    $(await_java_process_start "${client_class_name}") \
-    ; $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}") \
-    && tail --pid=\$! -f /dev/null; kill -9 \${media_driver_pid}; wait"
+    start_client="set -e
+       export JAVA_HOME=\"${CLIENT_JAVA_HOME}\"
+       export PROCESS_FILE_NAME=\"echo-client-media-driver\"
 
-    start_server="\
-    export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"echo-server-media-driver\"\
-    && ${server_driver} \
-    && numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} --physcpubind=\"${SERVER_NON_ISOLATED_CPU_CORES}\" ${SERVER_BENCHMARKS_PATH}/scripts/aeron/echo-server & \
-    $(await_java_process_start "${server_class_name}") \
-    ; $(pin_thread "\${pid}" "echo-0" "${SERVER_ECHO_CPU_CORE}") \
-    && tail --pid=\$! -f /dev/null"
+       $(kill_java_process "${client_class_name}")
+
+       ${client_driver}
+
+       numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} \
+         --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" \
+         ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/echo-client &
+
+       $(await_java_process_start "${client_class_name}")
+
+       pid=\${pid}
+       $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")
+
+       tail --pid=\$! -f /dev/null
+
+       kill -9 \${media_driver_pid}
+       wait
+       "
+
+    start_server="set -e
+       export JAVA_HOME=\"${SERVER_JAVA_HOME}\"
+       export PROCESS_FILE_NAME=\"echo-server-media-driver\"
+
+       ${server_driver}
+
+       numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} \
+         --physcpubind=\"${SERVER_NON_ISOLATED_CPU_CORES}\" \
+         ${SERVER_BENCHMARKS_PATH}/scripts/aeron/echo-server &
+
+       $(await_java_process_start "${server_class_name}")
+
+       pid=\${pid}
+       $(pin_thread "\${pid}" "echo-0" "${SERVER_ECHO_CPU_CORE}")
+
+       tail --pid=\$! -f /dev/null
+       "
 
     stop_server="$(stop_java_process "${server_class_name}"); \
     $(stop_media_driver)"

--- a/scripts/aeron/remote-echo-mdc-benchmarks
+++ b/scripts/aeron/remote-echo-mdc-benchmarks
@@ -208,20 +208,36 @@ function start_node()
   local destination_channel_var=NODE${node_id}_DESTINATION_CHANNEL
   local source_channel_var=NODE${node_id}_SOURCE_CHANNEL
   echo "
-    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"echo-node-media-driver-${node_id}\" \
-    ; $(kill_java_process "${node_class_name}") \
-    ; ${server_driver} \
-    && export JVM_OPTS=\"\
+    set -e
+
+    export JAVA_HOME=\"${!java_home_var}\"
+    export PROCESS_FILE_NAME=\"echo-node-media-driver-${node_id}\"
+
+    $(kill_java_process "${node_class_name}")
+
+    ${server_driver}
+
+    export JVM_OPTS=\"\
     -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout} \
     -Dio.aeron.benchmarks.output.directory=${output_dir} \
     -Dio.aeron.benchmarks.aeron.destination.channel=${!destination_channel_var} \
     -Dio.aeron.benchmarks.aeron.source.channel=${!source_channel_var} \
     -Dio.aeron.benchmarks.aeron.receiver.index=${node_id} \
-    ${!extra_properties_var:-}\" PROCESS_FILE_NAME=\"echo-node-${node_id}\" \
-    && numactl --membind=${!cpu_node_var} --cpunodebind=${!cpu_node_var} --physcpubind=\"${!non_isolated_cpu_cores_var}\" ${!benchmarks_path_var}/scripts/aeron/echo-server & \
-    $(await_java_process_start "${node_class_name}") \
-    ; $(pin_thread "\${pid}" "echo-${node_id}" "${!echo_cpu_var}") \
-    && tail --pid=\$! -f /dev/null"
+    ${!extra_properties_var:-}\"
+
+    export PROCESS_FILE_NAME=\"echo-node-${node_id}\"
+
+    numactl --membind=${!cpu_node_var} \
+            --cpunodebind=${!cpu_node_var} \
+            --physcpubind=\"${!non_isolated_cpu_cores_var}\" \
+            ${!benchmarks_path_var}/scripts/aeron/echo-server &
+
+    $(await_java_process_start "${node_class_name}")
+
+    $(pin_thread "\${pid}" "echo-${node_id}" "${!echo_cpu_var}")
+
+    tail --pid=\$! -f /dev/null
+    "
 }
 
 scripts_path="benchmarks_path_var/scripts/aeron"
@@ -370,30 +386,47 @@ do
 
           output_dir="${output_dir_prefix}/${test}_length=${messageLength}_rate=${messageRate}/run-${run}"
 
-          start_client="export JVM_OPTS=\"\
-          -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout}\
-          -Dio.aeron.benchmarks.warmup.iterations=${warmupIterations}\
-          -Dio.aeron.benchmarks.warmup.message.rate=${warmupMessageRate}\
-          -Dio.aeron.benchmarks.iterations=${iterations}\
-          -Dio.aeron.benchmarks.message.rate=${messageRate# }\
-          -Dio.aeron.benchmarks.batch.size=${burstSize# }\
-          -Dio.aeron.benchmarks.message.length=${messageLength# }\
-          -Dio.aeron.benchmarks.output.file=${test}\
-          -Dio.aeron.benchmarks.output.time.unit=${OUTPUT_TIME_UNIT:-MICROSECONDS}\
-          -Dio.aeron.benchmarks.track.history=${TRACK_HISTORY:-false}\
-          -Dio.aeron.benchmarks.report.progress=${REPORT_PROGRESS:-false}\
-          -Dio.aeron.benchmarks.output.directory=${CLIENT_BENCHMARKS_PATH}/${output_dir}\
-          -Dio.aeron.benchmarks.aeron.destination.channel=${CLIENT_DESTINATION_CHANNEL}\
-          -Dio.aeron.benchmarks.aeron.source.channel=${CLIENT_SOURCE_CHANNEL}\
-          -Dio.aeron.benchmarks.aeron.receiver.count=${RECEIVER_COUNT}\
-          ${CLIENT_EXTRA_PROPERTIES:-}\"\
-          && export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"client-media-driver\"\
-          ; $(kill_java_process "${client_class_name}")\
-          ; ${client_driver}\
-          && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/echo-client & \
-          $(await_java_process_start "${client_class_name}")\
-          ; $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")\
-          && tail --pid=\$! -f /dev/null; kill -9 \${media_driver_pid}; wait"
+          start_client="set -e
+
+            export JVM_OPTS=\"\
+              -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout} \
+              -Dio.aeron.benchmarks.warmup.iterations=${warmupIterations} \
+              -Dio.aeron.benchmarks.warmup.message.rate=${warmupMessageRate} \
+              -Dio.aeron.benchmarks.iterations=${iterations} \
+              -Dio.aeron.benchmarks.message.rate=${messageRate# } \
+              -Dio.aeron.benchmarks.batch.size=${burstSize# } \
+              -Dio.aeron.benchmarks.message.length=${messageLength# } \
+              -Dio.aeron.benchmarks.output.file=${test} \
+              -Dio.aeron.benchmarks.output.time.unit=${OUTPUT_TIME_UNIT:-MICROSECONDS} \
+              -Dio.aeron.benchmarks.track.history=${TRACK_HISTORY:-false} \
+              -Dio.aeron.benchmarks.report.progress=${REPORT_PROGRESS:-false} \
+              -Dio.aeron.benchmarks.output.directory=${CLIENT_BENCHMARKS_PATH}/${output_dir} \
+              -Dio.aeron.benchmarks.aeron.destination.channel=${CLIENT_DESTINATION_CHANNEL} \
+              -Dio.aeron.benchmarks.aeron.source.channel=${CLIENT_SOURCE_CHANNEL} \
+              -Dio.aeron.benchmarks.aeron.receiver.count=${RECEIVER_COUNT} \
+            ${CLIENT_EXTRA_PROPERTIES:-}\"
+
+            export JAVA_HOME=\"${CLIENT_JAVA_HOME}\"
+            export PROCESS_FILE_NAME=\"client-media-driver\"
+
+            $(kill_java_process "${client_class_name}")
+
+            ${client_driver}
+
+            numactl --membind=${CLIENT_CPU_NODE} \
+                    --cpunodebind=${CLIENT_CPU_NODE} \
+                    --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" \
+                    ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/echo-client &
+
+            $(await_java_process_start "${client_class_name}")
+
+            $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")
+
+            tail --pid=\$! -f /dev/null
+
+            kill -9 \${media_driver_pid}
+            wait
+            "
 
           for (( n=0; n<RECEIVER_COUNT; n++ ))
           do

--- a/scripts/aeron/remote-echo-single-host-benchmarks
+++ b/scripts/aeron/remote-echo-single-host-benchmarks
@@ -183,21 +183,33 @@ function start_node()
   local extra_properties_var=NODE${node_id}_EXTRA_PROPERTIES
   local destination_channel_var=NODE${node_id}_DESTINATION_CHANNEL
   local source_channel_var=NODE${node_id}_SOURCE_CHANNEL
-  echo "
-    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"echo-node-media-driver-${node_id}\" \
-    ; $(kill_java_process "${server_class_name}") \
-    ; ${server_driver} \
-    && export JVM_OPTS=\"\
-    -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout} \
-    -Dio.aeron.benchmarks.output.directory=${output_dir} \
-    -Dio.aeron.benchmarks.aeron.destination.channel=${!destination_channel_var} \
-    -Dio.aeron.benchmarks.aeron.source.channel=${!source_channel_var} \
-    -Dio.aeron.benchmarks.aeron.receiver.index=${node_id} \
-    ${!extra_properties_var:-}\" PROCESS_FILE_NAME=\"echo-node-${node_id}\" \
-    && numactl --membind=${!cpu_node_var} --cpunodebind=${!cpu_node_var} --physcpubind=\"${!non_isolated_cpu_cores_var}\" ${!benchmarks_path_var}/scripts/aeron/echo-server & \
-    $(await_java_process_start "${server_class_name}") \
-    ; $(pin_thread "\${pid}" "echo-${node_id}" "${!echo_cpu_var}") \
-    && tail --pid=\$! -f /dev/null"
+  echo "set -e
+     export JAVA_HOME=\"${!java_home_var}\"
+     export PROCESS_FILE_NAME=\"echo-node-media-driver-${node_id}\"
+
+     $(kill_java_process "${server_class_name}")
+
+     ${server_driver}
+
+     export JVM_OPTS=\"\
+     -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout} \
+     -Dio.aeron.benchmarks.output.directory=${output_dir} \
+     -Dio.aeron.benchmarks.aeron.destination.channel=${!destination_channel_var} \
+     -Dio.aeron.benchmarks.aeron.source.channel=${!source_channel_var} \
+     -Dio.aeron.benchmarks.aeron.receiver.index=${node_id} \
+     ${!extra_properties_var:-}\"
+     export PROCESS_FILE_NAME=\"echo-node-${node_id}\"
+
+     numactl --membind=${!cpu_node_var} --cpunodebind=${!cpu_node_var} \
+       --physcpubind=\"${!non_isolated_cpu_cores_var}\" \
+       ${!benchmarks_path_var}/scripts/aeron/echo-server &
+
+     $(await_java_process_start "${server_class_name}")
+
+     pid=\${pid}
+     $(pin_thread "\${pid}" "echo-${node_id}" "${!echo_cpu_var}")
+
+     tail --pid=\$! -f /dev/null"
 }
 
 scripts_path="benchmarks_path_var/scripts/aeron"
@@ -331,31 +343,55 @@ do
 
           output_dir="${output_dir_prefix}/${test}_length=${messageLength}_rate=${messageRate}/run-${run}"
 
-          benchmark_command="export JVM_OPTS=\"\
-          -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout}\
-          -Dio.aeron.benchmarks.warmup.iterations=${warmupIterations}\
-          -Dio.aeron.benchmarks.warmup.message.rate=${warmupMessageRate}\
-          -Dio.aeron.benchmarks.iterations=${iterations}\
-          -Dio.aeron.benchmarks.message.rate=${messageRate# }\
-          -Dio.aeron.benchmarks.batch.size=${burstSize# }\
-          -Dio.aeron.benchmarks.message.length=${messageLength# }\
-          -Dio.aeron.benchmarks.output.file=${test}\
-          -Dio.aeron.benchmarks.output.time.unit=${OUTPUT_TIME_UNIT:-MICROSECONDS}\
-          -Dio.aeron.benchmarks.track.history=${TRACK_HISTORY:-false}\
-          -Dio.aeron.benchmarks.report.progress=${REPORT_PROGRESS:-false}\
-          -Dio.aeron.benchmarks.output.directory=${BENCHMARKS_PATH}/${output_dir}\
-          -Dio.aeron.benchmarks.aeron.destination.channel=${DESTINATION_CHANNEL}\
-          -Dio.aeron.benchmarks.aeron.source.channel=${SOURCE_CHANNEL}\"\
-          && export JAVA_HOME=\"${JAVA_HOME}\"\
-          ; $(kill_java_process "${client_class_name}")\
-          ; $(kill_java_process "${server_class_name}")\
-          ; ${media_driver}\
-          && numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} --physcpubind=\"${NON_ISOLATED_CPU_CORES}\" ${BENCHMARKS_PATH}/scripts/aeron/echo-server & \
-          $(await_java_process_start "${server_class_name}"); echo_pid=\${pid}; echo \"echo_pid=\${echo_pid}\" \
-          && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${NON_ISOLATED_CPU_CORES}\" ${BENCHMARKS_PATH}/scripts/aeron/echo-client & \
-          $(await_java_process_start "${client_class_name}"); load_test_rig_pid=\${pid}; echo \"load_test_rig_pid=\${load_test_rig_pid}\" \
-          && $(pin_thread "\${echo_pid}" "echo-0" "${SERVER_ECHO_CPU_CORE}"); $(pin_thread "\${load_test_rig_pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}") \
-          && tail --pid=\$! -f /dev/null; kill -9 \${echo_pid}; kill -9 \${media_driver_pid}; wait"
+         benchmark_command="set -e
+
+           export JVM_OPTS=\"\
+           -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout} \
+           -Dio.aeron.benchmarks.warmup.iterations=${warmupIterations} \
+           -Dio.aeron.benchmarks.warmup.message.rate=${warmupMessageRate} \
+           -Dio.aeron.benchmarks.iterations=${iterations} \
+           -Dio.aeron.benchmarks.message.rate=${messageRate# } \
+           -Dio.aeron.benchmarks.batch.size=${burstSize# } \
+           -Dio.aeron.benchmarks.message.length=${messageLength# } \
+           -Dio.aeron.benchmarks.output.file=${test} \
+           -Dio.aeron.benchmarks.output.time.unit=${OUTPUT_TIME_UNIT:-MICROSECONDS} \
+           -Dio.aeron.benchmarks.track.history=${TRACK_HISTORY:-false} \
+           -Dio.aeron.benchmarks.report.progress=${REPORT_PROGRESS:-false} \
+           -Dio.aeron.benchmarks.output.directory=${BENCHMARKS_PATH}/${output_dir} \
+           -Dio.aeron.benchmarks.aeron.destination.channel=${DESTINATION_CHANNEL} \
+           -Dio.aeron.benchmarks.aeron.source.channel=${SOURCE_CHANNEL}\"
+
+           export JAVA_HOME=\"${JAVA_HOME}\"
+
+           $(kill_java_process "${client_class_name}")
+           $(kill_java_process "${server_class_name}")
+
+           ${media_driver}
+
+           numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} \
+             --physcpubind=\"${NON_ISOLATED_CPU_CORES}\" \
+             ${BENCHMARKS_PATH}/scripts/aeron/echo-server &
+
+           $(await_java_process_start "${server_class_name}")
+           echo_pid=\${pid}
+           echo \"echo_pid=\${echo_pid}\"
+
+           numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} \
+             --physcpubind=\"${NON_ISOLATED_CPU_CORES}\" \
+             ${BENCHMARKS_PATH}/scripts/aeron/echo-client &
+
+           $(await_java_process_start "${client_class_name}")
+           load_test_rig_pid=\${pid}
+           echo \"load_test_rig_pid=\${load_test_rig_pid}\"
+
+           $(pin_thread "\${echo_pid}" "echo-0" "${SERVER_ECHO_CPU_CORE}")
+           $(pin_thread "\${load_test_rig_pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")
+
+           tail --pid=\$! -f /dev/null
+           kill -9 \${echo_pid}
+           kill -9 \${media_driver_pid}
+           wait
+          "
 
           echo -e "\nRunning benchmark..."
           execute_remote_command "${SSH_CLIENT_USER}" "${SSH_CLIENT_KEY_FILE}" "${SSH_CLIENT_NODE}" "${benchmark_command}; cp /dev/shm/*-gc.log \"${BENCHMARKS_PATH}/${output_dir}/logs\"; cp /dev/shm/*-crash.log \"${BENCHMARKS_PATH}/${output_dir}/logs\"; rm /dev/shm/*-gc.log; rm /dev/shm/*-crash.log; true; exit"

--- a/scripts/aeron/remote-live-recording-benchmarks
+++ b/scripts/aeron/remote-live-recording-benchmarks
@@ -264,28 +264,57 @@ do
         client_interface="|interface=${CLIENT_INTERFACE}"
       fi
 
-      start_client="\
-      export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"live-recording-client-media-driver\"\
-      ; $(kill_java_process "${client_class_name}") \
-      ; rm -rf ${ARCHIVE_DIR} \
-      ; sync; echo 3 | sudo tee /proc/sys/vm/drop_caches; fstrim --all \
-      ; ${client_driver} \
-      && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/live-recording-client & \
-      $(await_java_process_start "${client_class_name}") \
-      ; $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}") \
-      ; $(pin_thread "\${pid}" "archive-recorde" "${CLIENT_LOAD_TEST_RIG_ARCHIVE_RECORDER_CPU_CORE}") \
-      ; $(pin_thread "\${pid}" "archive-replaye" "${CLIENT_LOAD_TEST_RIG_ARCHIVE_REPLAYER_CPU_CORE}") \
-      ; $(pin_thread "\${pid}" "archive-conduct" "${CLIENT_LOAD_TEST_RIG_ARCHIVE_CONDUCTOR_CPU_CORE}") \
-      && tail --pid=\$! -f /dev/null && kill -9 \${media_driver_pid}; wait"
+      start_client="set -e
+        export JAVA_HOME=\"${CLIENT_JAVA_HOME}\"
+        export PROCESS_FILE_NAME=\"live-recording-client-media-driver\"
 
-      start_server="\
-      export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"echo-node-media-driver\"\
-      ; $(kill_java_process "${server_class_name}") \
-      ; ${server_driver} \
-      && numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} --physcpubind=\"${SERVER_NON_ISOLATED_CPU_CORES}\" ${SERVER_BENCHMARKS_PATH}/scripts/aeron/echo-server & \
-      $(await_java_process_start "${server_class_name}") \
-      ; $(pin_thread "\${pid}" "echo" "${SERVER_ECHO_CPU_CORE}") \
-      && tail --pid=\$! -f /dev/null"
+        $(kill_java_process "${client_class_name}")
+
+        rm -rf ${ARCHIVE_DIR}
+
+        sync
+        echo 3 | sudo tee /proc/sys/vm/drop_caches
+        fstrim --all
+
+        ${client_driver}
+
+        numactl --membind=${CLIENT_CPU_NODE} \
+                --cpunodebind=${CLIENT_CPU_NODE} \
+                --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" \
+                ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/live-recording-client &
+
+        $(await_java_process_start "${client_class_name}")
+
+        $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")
+        $(pin_thread "\${pid}" "archive-recorde" "${CLIENT_LOAD_TEST_RIG_ARCHIVE_RECORDER_CPU_CORE}")
+        $(pin_thread "\${pid}" "archive-replaye" "${CLIENT_LOAD_TEST_RIG_ARCHIVE_REPLAYER_CPU_CORE}")
+        $(pin_thread "\${pid}" "archive-conduct" "${CLIENT_LOAD_TEST_RIG_ARCHIVE_CONDUCTOR_CPU_CORE}")
+
+        tail --pid=\$! -f /dev/null
+
+        kill -9 \${media_driver_pid}
+        wait
+        "
+
+      start_server="set -e
+        export JAVA_HOME=\"${SERVER_JAVA_HOME}\"
+        export PROCESS_FILE_NAME=\"echo-node-media-driver\"
+
+        $(kill_java_process "${server_class_name}")
+
+        ${server_driver}
+
+        numactl --membind=${SERVER_CPU_NODE} \
+                --cpunodebind=${SERVER_CPU_NODE} \
+                --physcpubind=\"${SERVER_NON_ISOLATED_CPU_CORES}\" \
+                ${SERVER_BENCHMARKS_PATH}/scripts/aeron/echo-server &
+
+        $(await_java_process_start "${server_class_name}")
+
+        $(pin_thread "\${pid}" "echo" "${SERVER_ECHO_CPU_CORE}")
+
+        tail --pid=\$! -f /dev/null
+        "
 
       stop_server="$(stop_java_process "${server_class_name}"); $(stop_media_driver)"
 

--- a/scripts/aeron/remote-live-replay-benchmarks
+++ b/scripts/aeron/remote-live-replay-benchmarks
@@ -264,28 +264,57 @@ do
         client_interface="|interface=${CLIENT_INTERFACE}"
       fi
 
-      start_client="\
-      export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"live-replay-client-media-driver\"\
-      ; $(kill_java_process "${client_class_name}") \
-      ; ${client_driver} \
-      && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/live-replay-client & \
-      $(await_java_process_start "${client_class_name}") \
-      ; $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}") \
-      && tail --pid=\$! -f /dev/null && kill -9 \${media_driver_pid}; wait"
+      start_client="set -e
+        export JAVA_HOME=\"${CLIENT_JAVA_HOME}\"
+        export PROCESS_FILE_NAME=\"live-replay-client-media-driver\"
 
-      start_server="\
-      export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"archive-node-media-driver\" \
-      ; $(kill_java_process "${server_class_name}") \
-      ; rm -rf ${ARCHIVE_DIR} \
-      ; sync; echo 3 | sudo tee /proc/sys/vm/drop_caches; fstrim --all \
-      ; ${server_driver} \
-      && numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} --physcpubind=\"${SERVER_NON_ISOLATED_CPU_CORES}\" ${SERVER_BENCHMARKS_PATH}/scripts/aeron/archive-node & \
-      $(await_java_process_start "${server_class_name}") \
-      ; $(pin_thread "\${pid}" "archive-recorde" "${SERVER_ARCHIVE_RECORDER_CPU_CORE}") \
-      ; $(pin_thread "\${pid}" "archive-replaye" "${SERVER_ARCHIVE_REPLAYER_CPU_CORE}") \
-      ; $(pin_thread "\${pid}" "archive-conduct" "${SERVER_ARCHIVE_CONDUCTOR_CPU_CORE}") \
-      ; $(pin_thread "\${pid}" "archive-node" "${SERVER_ARCHIVE_NODE_CPU_CORE}") \
-      && tail --pid=\$! -f /dev/null"
+        $(kill_java_process "${client_class_name}")
+
+        ${client_driver}
+
+        numactl --membind=${CLIENT_CPU_NODE} \
+                --cpunodebind=${CLIENT_CPU_NODE} \
+                --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" \
+                ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/live-replay-client &
+
+        $(await_java_process_start "${client_class_name}")
+
+        $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")
+
+        tail --pid=\$! -f /dev/null
+
+        kill -9 \${media_driver_pid}
+        wait
+        "
+
+      start_server="set -e
+        export JAVA_HOME=\"${SERVER_JAVA_HOME}\"
+        export PROCESS_FILE_NAME=\"archive-node-media-driver\"
+
+        $(kill_java_process "${server_class_name}")
+
+        rm -rf ${ARCHIVE_DIR}
+
+        sync
+        echo 3 | sudo tee /proc/sys/vm/drop_caches
+        fstrim --all
+
+        ${server_driver}
+
+        numactl --membind=${SERVER_CPU_NODE} \
+                --cpunodebind=${SERVER_CPU_NODE} \
+                --physcpubind=\"${SERVER_NON_ISOLATED_CPU_CORES}\" \
+                ${SERVER_BENCHMARKS_PATH}/scripts/aeron/archive-node &
+
+        $(await_java_process_start "${server_class_name}")
+
+        $(pin_thread "\${pid}" "archive-recorde" "${SERVER_ARCHIVE_RECORDER_CPU_CORE}")
+        $(pin_thread "\${pid}" "archive-replaye" "${SERVER_ARCHIVE_REPLAYER_CPU_CORE}")
+        $(pin_thread "\${pid}" "archive-conduct" "${SERVER_ARCHIVE_CONDUCTOR_CPU_CORE}")
+        $(pin_thread "\${pid}" "archive-node" "${SERVER_ARCHIVE_NODE_CPU_CORE}")
+
+        tail --pid=\$! -f /dev/null
+        "
 
       stop_server="$(stop_java_process "${server_class_name}"); $(stop_media_driver)"
 

--- a/scripts/grpc/remote-grpc-benchmarks
+++ b/scripts/grpc/remote-grpc-benchmarks
@@ -123,16 +123,32 @@ do
 
   echo -e "\n Testing scenario: '${test}'\n"
 
-  start_client="export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"grpc-client\"\
-  ; $(kill_java_process "io.aeron.benchmarks.LoadTestRig") \
-  ; numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} ${onload} ${CLIENT_BENCHMARKS_PATH}/scripts/grpc/client & \
-  $(await_java_process_start "io.aeron.benchmarks.LoadTestRig"); \
-  $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}") \
-  && tail --pid=\$! -f /dev/null"
+  start_client="
+    set -e
+    export JAVA_HOME=\"${CLIENT_JAVA_HOME}\"
+    export PROCESS_FILE_NAME=\"grpc-client\"
+
+    $(kill_java_process "io.aeron.benchmarks.LoadTestRig")
+
+    numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} \
+      ${onload} ${CLIENT_BENCHMARKS_PATH}/scripts/grpc/client &
+
+    $(await_java_process_start \"io.aeron.benchmarks.LoadTestRig\")
+
+    $(pin_thread \"\${pid}\" \"load-test-rig\" \"${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}\")
+
+    tail --pid=\$! -f /dev/null
+    "
 
   # shellcheck disable=SC2153
-  start_server="export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"grpc-server\"\
-  && numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} ${onload} ${SERVER_BENCHMARKS_PATH}/scripts/grpc/server"
+  start_server="
+    set -e
+    export JAVA_HOME=\"${SERVER_JAVA_HOME}\"
+    export PROCESS_FILE_NAME=\"grpc-server\"
+
+    numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} \
+      ${onload} ${SERVER_BENCHMARKS_PATH}/scripts/grpc/server
+    "
 
   stop_server="$(stop_java_process "io.aeron.benchmarks.grpc.EchoServer")"
 

--- a/scripts/kafka/remote-kafka-benchmarks
+++ b/scripts/kafka/remote-kafka-benchmarks
@@ -128,26 +128,51 @@ do
 
     echo -e "\n Testing scenario: '${test}'\n"
 
-    start_client="export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" \
-    ; $(kill_java_process "io.aeron.benchmarks.LoadTestRig") \
-      ; numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} ${onload} ${CLIENT_BENCHMARKS_PATH}/scripts/kafka/client &
-      $(await_java_process_start "io.aeron.benchmarks.LoadTestRig"); \
-      $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}") \
-      && tail --pid=\$! -f /dev/null"
+    start_client="
+      set -e
+
+      export JAVA_HOME=\"${CLIENT_JAVA_HOME}\"
+      export PROCESS_FILE_NAME=\"kafka-client\"
+
+      $(kill_java_process "io.aeron.benchmarks.LoadTestRig")
+
+      numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} \
+        ${onload} ${CLIENT_BENCHMARKS_PATH}/scripts/kafka/client &
+
+      $(await_java_process_start \"io.aeron.benchmarks.LoadTestRig\")
+
+      $(pin_thread \"\${pid}\" \"load-test-rig\" \"${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}\")
+
+      tail --pid=\$! -f /dev/null
+      "
 
     server_scripts_path="${SERVER_BENCHMARKS_PATH}/scripts/kafka"
 
-    start_kafka="cp ${server_scripts_path}/server.properties ${server_scripts_path}/server.properties.bak \
-    && echo -e \"log.dirs=${SERVER_KAFKA_DIR}/logs\n\
-    ssl.truststore.location=${SERVER_BENCHMARKS_PATH}/certificates/truststore.p12\n\
-    ssl.keystore.location=${SERVER_BENCHMARKS_PATH}/certificates/server.keystore\n\
-    advertised.listeners=PLAINTEXT://${SERVER_HOST}:${plain_text_port},SSL://${SERVER_HOST}:${ssl_port}\" >> ${server_scripts_path}/server.properties \
-    && export JAVA_HOME=\"${SERVER_JAVA_HOME}\" \
-    && numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} ${onload} ${server_scripts_path}/kafka-start"
+    start_kafka="
+      set -e
 
-    stop_server="export JAVA_HOME=\"${SERVER_JAVA_HOME}\" \
-    && KAFKA_DATA_DIR=\"${SERVER_KAFKA_DIR}\" ${server_scripts_path}/stop-all; \
-    mv ${server_scripts_path}/server.properties.bak ${server_scripts_path}/server.properties"
+      cp ${server_scripts_path}/server.properties ${server_scripts_path}/server.properties.bak
+
+      echo -e \"log.dirs=${SERVER_KAFKA_DIR}/logs
+      ssl.truststore.location=${SERVER_BENCHMARKS_PATH}/certificates/truststore.p12
+      ssl.keystore.location=${SERVER_BENCHMARKS_PATH}/certificates/server.keystore
+      advertised.listeners=PLAINTEXT://${SERVER_HOST}:${plain_text_port},SSL://${SERVER_HOST}:${ssl_port}\" >> ${server_scripts_path}/server.properties
+
+      export JAVA_HOME=\"${SERVER_JAVA_HOME}\"
+
+      numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} \
+        ${onload} ${server_scripts_path}/kafka-start
+      "
+
+    stop_server="
+      set -e
+
+      export JAVA_HOME=\"${SERVER_JAVA_HOME}\"
+
+      KAFKA_DATA_DIR=\"${SERVER_KAFKA_DIR}\" ${server_scripts_path}/stop-all
+
+      mv ${server_scripts_path}/server.properties.bak ${server_scripts_path}/server.properties
+      "
 
     run_benchmarks \
       "${start_client}" \


### PR DESCRIPTION
Instead of using a chain of commands using &&, the script is run with -e and the now there is a sequence of commands.

The original code was pretty hard to understand and this should improve maintainability.