### PR TITLE
await_process_start improve timeout message.

### DIFF
--- a/scripts/remote-benchmarks-runner
+++ b/scripts/remote-benchmarks-runner
@@ -179,7 +179,7 @@ function await_process_start()
       count=\$((count + 1));
     done;
     if [ -z \"\${pid}\" ]; then
-       echo 'Timeout: process not found after 60 seconds.';
+       echo 'Timeout: process not found after 60 seconds for command: ${pid_cmd}';
        exit 1;
     fi;
     echo \"pid='\${pid}'\"


### PR DESCRIPTION
Include the pid_cmd in the timeout message so it is easier to determine what you are waiting for.