### PR TITLE
Using SIGTERM instead of SIGKILL.

### DIFF
--- a/scripts/aeron/remote-archive-replay-mdc-benchmarks
+++ b/scripts/aeron/remote-archive-replay-mdc-benchmarks
@@ -431,7 +431,7 @@ do
             && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/echo-client & \
             $(await_java_process_start "${client_class_name}")\
             ; $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")\
-            && tail --pid=\$! -f /dev/null; kill -9 \${media_driver_pid}; wait"
+            && tail --pid=\$! -f /dev/null; kill -SIGTERM \${media_driver_pid}; wait"
 
             start_server="export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"archive-node-media-driver\"\
             ; $(kill_java_process "${server_class_name}") \

--- a/scripts/aeron/remote-benchmarks-helper
+++ b/scripts/aeron/remote-benchmarks-helper
@@ -60,5 +60,5 @@ function start_media_driver()
 
 function stop_media_driver()
 {
-  echo "sudo pkill -9 '^aeronmd'; $(kill_java_process "io.aeron.driver.MediaDriver")"
+  echo "sudo pkill -SIGTERM '^aeronmd'; $(kill_java_process "io.aeron.driver.MediaDriver")"
 }

--- a/scripts/aeron/remote-cluster-benchmarks
+++ b/scripts/aeron/remote-cluster-benchmarks
@@ -518,7 +518,7 @@ do
             && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/${client_script} & \
             $(await_java_process_start "${client_class_name}")\
             ; $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")\
-            && tail --pid=\$! -f /dev/null; kill -9 \${media_driver_pid}; wait"
+            && tail --pid=\$! -f /dev/null; kill -SIGTERM \${media_driver_pid}; wait"
 
             for (( n=0; n<CLUSTER_BACKUP_NODES; n++ ))
             do

--- a/scripts/aeron/remote-echo-benchmarks
+++ b/scripts/aeron/remote-echo-benchmarks
@@ -293,7 +293,7 @@ do
     && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/echo-client & \
     $(await_java_process_start "${client_class_name}") \
     ; $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}") \
-    && tail --pid=\$! -f /dev/null; kill -9 \${media_driver_pid}; wait"
+    && tail --pid=\$! -f /dev/null; kill -SIGTERM \${media_driver_pid}; wait"
 
     start_server="\
     export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"echo-server-media-driver\"\

--- a/scripts/aeron/remote-echo-mdc-benchmarks
+++ b/scripts/aeron/remote-echo-mdc-benchmarks
@@ -393,7 +393,7 @@ do
           && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/echo-client & \
           $(await_java_process_start "${client_class_name}")\
           ; $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")\
-          && tail --pid=\$! -f /dev/null; kill -9 \${media_driver_pid}; wait"
+          && tail --pid=\$! -f /dev/null; kill -SIGTERM \${media_driver_pid}; wait"
 
           for (( n=0; n<RECEIVER_COUNT; n++ ))
           do

--- a/scripts/aeron/remote-echo-single-host-benchmarks
+++ b/scripts/aeron/remote-echo-single-host-benchmarks
@@ -355,7 +355,7 @@ do
           && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${NON_ISOLATED_CPU_CORES}\" ${BENCHMARKS_PATH}/scripts/aeron/echo-client & \
           $(await_java_process_start "${client_class_name}"); load_test_rig_pid=\${pid}; echo \"load_test_rig_pid=\${load_test_rig_pid}\" \
           && $(pin_thread "\${echo_pid}" "echo-0" "${SERVER_ECHO_CPU_CORE}"); $(pin_thread "\${load_test_rig_pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}") \
-          && tail --pid=\$! -f /dev/null; kill -9 \${echo_pid}; kill -9 \${media_driver_pid}; wait"
+          && tail --pid=\$! -f /dev/null; kill -SIGTERM \${echo_pid}; kill -9 \${media_driver_pid}; wait"
 
           echo -e "\nRunning benchmark..."
           execute_remote_command "${SSH_CLIENT_USER}" "${SSH_CLIENT_KEY_FILE}" "${SSH_CLIENT_NODE}" "${benchmark_command}; cp /dev/shm/*-gc.log \"${BENCHMARKS_PATH}/${output_dir}/logs\"; cp /dev/shm/*-crash.log \"${BENCHMARKS_PATH}/${output_dir}/logs\"; rm /dev/shm/*-gc.log; rm /dev/shm/*-crash.log; true; exit"

--- a/scripts/aeron/remote-live-recording-benchmarks
+++ b/scripts/aeron/remote-live-recording-benchmarks
@@ -276,7 +276,7 @@ do
       ; $(pin_thread "\${pid}" "archive-recorde" "${CLIENT_LOAD_TEST_RIG_ARCHIVE_RECORDER_CPU_CORE}") \
       ; $(pin_thread "\${pid}" "archive-replaye" "${CLIENT_LOAD_TEST_RIG_ARCHIVE_REPLAYER_CPU_CORE}") \
       ; $(pin_thread "\${pid}" "archive-conduct" "${CLIENT_LOAD_TEST_RIG_ARCHIVE_CONDUCTOR_CPU_CORE}") \
-      && tail --pid=\$! -f /dev/null && kill -9 \${media_driver_pid}; wait"
+      && tail --pid=\$! -f /dev/null && kill -SIGTERM \${media_driver_pid}; wait"
 
       start_server="\
       export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"echo-node-media-driver\"\

--- a/scripts/aeron/remote-live-replay-benchmarks
+++ b/scripts/aeron/remote-live-replay-benchmarks
@@ -271,7 +271,7 @@ do
       && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/live-replay-client & \
       $(await_java_process_start "${client_class_name}") \
       ; $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}") \
-      && tail --pid=\$! -f /dev/null && kill -9 \${media_driver_pid}; wait"
+      && tail --pid=\$! -f /dev/null && kill -SIGTERM \${media_driver_pid}; wait"
 
       start_server="\
       export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"archive-node-media-driver\" \

--- a/scripts/kafka/stop-all
+++ b/scripts/kafka/stop-all
@@ -27,7 +27,7 @@ killJavaProcess() {
     if [[ -z "${pid}" ]]; then
       echo "${name} is not running"
     else
-      kill -9 "${pid}"
+      kill -SIGTERM "${pid}"
     fi
 }
 

--- a/scripts/remote-benchmarks-runner
+++ b/scripts/remote-benchmarks-runner
@@ -230,7 +230,7 @@ function pin_thread()
 function kill_java_process()
 {
   local class_name=${1}
-  echo "kill -9 $(find_java_process "${class_name}")"
+  echo "kill -SIGTERM $(find_java_process "${class_name}")"
 }
 
 function stop_java_process()


### PR DESCRIPTION
The drawback of the SIGKILL is that it leads to corrupted profiles when running with the async-profiler.