### PR TITLE
Fixed naming of benchmark.tar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -296,6 +296,7 @@ tasks.register('deployTar', Tar) {
     from(cDriverDpdkTree)
     from(cDriverAtsTree)
     from(cDriverEfviTree)
+    archiveFileName = 'benchmarks.tar'
 }
 
 tasks.register('copyTestLogs', Copy) {


### PR DESCRIPTION
It will not include the version and will have a fixed name.

The inclusion of the version was triggered by this PR:
https://github.com/aeron-io/benchmarks/pull/73