### PR TITLE
collect-environment-info: Add topology-xml section.

### DIFF
--- a/scripts/collect-environment-info
+++ b/scripts/collect-environment-info
@@ -57,7 +57,8 @@ fi
 OPENSSL_VERSION=$(openssl version)
 
 TOPO=$(lstopo --of txt)
-TOPO_JSON=$(jq -n --arg topo "$TOPO" '{ topology: $topo }')
+TOPO_XML=$(lstopo --of xml)
+TOPO_JSON=$(jq -n --arg topo "$TOPO" --arg topo_xml "$TOPO_XML" '{ topology: $topo, "topology-xml": $topo_xml }')
 
 JSON_SUMMARY=$( jq -n \
                   --arg manufacturer "$MANUFACTURER" \


### PR DESCRIPTION
With this PR, he topology is also stored in XML format to make it a lot easier to parse.

Especially the topology of the CPU internals with its NUMA nodes, caches, cores etc etc.