### PR TITLE
Fix scripts file attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -285,6 +285,11 @@ FileTree cDriverAtsTree = (project.hasProperty('aeron.cdriver.ats.package')) ?
 
 tasks.register('deployTar', Tar) {
     dependsOn ':benchmarks-all:shadowJar'
+
+    preserveFileTimestamps = true
+    reproducibleFileOrder = false
+    useFileSystemPermissions()
+
     from(benchmarksFileTree)
     from(cDriverTree) {
         include "*/**"


### PR DESCRIPTION
After the upgrade to gradle 9.0:

https://github.com/aeron-io/benchmarks/commit/a28e2fc7925ae7271dbda2461566ea01637f5655

The file dates and permissions were no longer copied. So e.g. the executable permission was lost on the script files and the benchmarks stopped running.

This PR fixes that (restores the original behavior).