### PR TITLE
Added io.aeron.benchmarks.output.directory to media driver

### DIFF
--- a/scripts/aeron/remote-cluster-benchmarks
+++ b/scripts/aeron/remote-cluster-benchmarks
@@ -350,6 +350,7 @@ function start_cluster_backup_node()
 scripts_path="benchmarks_path_var/scripts/aeron"
 
 driver_properties="echo -e \"\
+io.aeron.benchmarks.output.directory=${output_dir}\n\
 aeron.dir=${AERON_DIR:-/dev/shm/aeron}\n\
 aeron.file.page.size=${AERON_FILE_PAGE_SIZE:-4k}\n\
 aeron.term.buffer.sparse.file=${AERON_TERM_BUFFER_SPARSE_FILE:-true}\n\


### PR DESCRIPTION
The purpose of this addition is to have the output.directory available in the media driver scripts. 

So that e.g. async profiler or other tooling can write in the correct directly so it gets downloaded when the benchmark completes.