### PR TITLE
Added OUTPUT_DIR environment var.

### DIFF
--- a/scripts/aeron/remote-archive-replay-mdc-benchmarks
+++ b/scripts/aeron/remote-archive-replay-mdc-benchmarks
@@ -230,7 +230,7 @@ function start_replay_node()
   local archive_response_channel_var=NODE${node_id}_ARCHIVE_RESPONSE_CHANNEL
   local replay_channel_var=NODE${node_id}_REPLAY_CHANNEL
   echo "
-    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"replay-node-media-driver-${node_id}\" \
+    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"replay-node-media-driver-${node_id}\" OUTPUT_DIR=\"${output_dir}\"\
     ; $(kill_java_process "${node_class_name}") \
     ; ${server_driver} \
     && export JVM_OPTS=\"\
@@ -424,21 +424,21 @@ do
             -Dio.aeron.benchmarks.aeron.source.channel=${SOURCE_CHANNEL}\
             -Dio.aeron.benchmarks.aeron.receiver.count=${RECEIVER_COUNT}\
             ${CLIENT_EXTRA_PROPERTIES:-}\"\
-            && export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"client-media-driver\"\
+            && export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"client-media-driver\" OUTPUT_DIR=\"${output_dir}\" \
             ; $(kill_java_process "${client_class_name}")\
             ; ${client_driver}\
-            ; export PROCESS_FILE_NAME=\"echo-client\"\
+            ; export PROCESS_FILE_NAME=\"echo-client\" OUTPUT_DIR=\"${output_dir}\"\
             && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/echo-client & \
             $(await_java_process_start "${client_class_name}")\
             ; $(pin_thread "\${pid}" "load-test-rig" "${CLIENT_LOAD_TEST_RIG_MAIN_CPU_CORE}")\
             && tail --pid=\$! -f /dev/null; kill -SIGTERM \${media_driver_pid}; wait"
 
-            start_server="export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"archive-node-media-driver\"\
+            start_server="export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"archive-node-media-driver\" OUTPUT_DIR=\"${output_dir}\"\
             ; $(kill_java_process "${server_class_name}") \
             ; rm -rf ${ARCHIVE_DIR} \
             ; sync; echo 3 | sudo tee /proc/sys/vm/drop_caches; sudo fstrim --all \
             ; ${server_driver} \
-            && export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"archive-node\" \
+            && export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"archive-node\" OUTPUT_DIR=\"${output_dir}\"\
             JVM_OPTS=\"\
             -Dio.aeron.benchmarks.aeron.connection.timeout=${connectionTimeout}\
             -Dio.aeron.benchmarks.output.directory=${SERVER_BENCHMARKS_PATH}/${output_dir} \

--- a/scripts/aeron/remote-cluster-benchmarks
+++ b/scripts/aeron/remote-cluster-benchmarks
@@ -242,7 +242,7 @@ function start_cluster_node()
   local clustered_service_cpu_var=NODE${node_id}_CLUSTERED_SERVICE_CPU_CORE
   local extra_properties_var=NODE${node_id}_EXTRA_PROPERTIES
   echo "
-    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"cluster-node-${node_id}-media-driver\" \
+    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"cluster-node-${node_id}-media-driver\" OUTPUT_DIR=\"${output_dir}\"\
     ; $(kill_java_process "${cluster_node_class_name}") \
     ; rm -rf \"${!cluster_dir_var}\" \
     ; rm -rf \"${!archive_dir_var}\" \
@@ -274,7 +274,7 @@ function start_cluster_node()
     -Daeron.archive.control.response.stream.id=120 \
     -Dio.aeron.benchmarks.aeron.cluster.service=${cluster_service} \
     -Dio.aeron.benchmarks.output.directory=${output_dir} \
-    ${!extra_properties_var:-}\" PROCESS_FILE_NAME=\"cluster-node-${node_id}\" \
+    ${!extra_properties_var:-}\" PROCESS_FILE_NAME=\"cluster-node-${node_id}\" OUTPUT_DIR=\"${output_dir}\"\
     && numactl --membind=${!cpu_node_var} --cpunodebind=${!cpu_node_var} --physcpubind=\"${!non_isolated_cpu_cores_var}\" ${!benchmarks_path_var}/scripts/aeron/cluster-node & \
     $(await_java_process_start "${cluster_node_class_name}") \
     ; $(pin_thread "\${pid}" "archive-recorde" "${!archive_recorder_cpu_var}") \
@@ -309,7 +309,7 @@ function start_cluster_backup_node()
   local archive_conductor_cpu_var=BACKUP_NODE${node_id}_ARCHIVE_CONDUCTOR_CPU_CORE
   local cluster_backup_cpu_var=BACKUP_NODE${node_id}_CLUSTER_BACKUP_CPU_CORE
   echo "
-    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"cluster-backup-node-${node_id}-media-driver\" \
+    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"cluster-backup-node-${node_id}-media-driver\" OUTPUT_DIR=\"${output_dir}\"\
     ; $(kill_java_process "${cluster_backup_node_class_name}") \
     ; rm -rf \"${!cluster_dir_var}\" \
     ; rm -rf \"${!archive_dir_var}\" \
@@ -337,7 +337,7 @@ function start_cluster_backup_node()
     -Daeron.archive.local.control.stream.id=110 \
     -Daeron.archive.control.stream.id=110 \
     -Daeron.archive.control.response.stream.id=120 \
-    -Dio.aeron.benchmarks.output.directory=${output_dir}\" PROCESS_FILE_NAME=\"cluster-backup-node-${node_id}\"\
+    -Dio.aeron.benchmarks.output.directory=${output_dir}\" PROCESS_FILE_NAME=\"cluster-backup-node-${node_id}\" OUTPUT_DIR=\"${output_dir}\"\
     && numactl --membind=${!cpu_node_var} --cpunodebind=${!cpu_node_var} --physcpubind=\"${!non_isolated_cpu_cores_var}\" ${!benchmarks_path_var}/scripts/aeron/cluster-backup-node & \
     $(await_java_process_start "${cluster_backup_node_class_name}") \
     ; $(pin_thread "\${pid}" "archive-recorde" "${!archive_recorder_cpu_var}") \
@@ -519,7 +519,7 @@ do
             -Daeron.cluster.egress.channel=${CLIENT_EGRESS_CHANNEL}\
             -Daeron.cluster.message.timeout=300000000000\
             ${CLIENT_EXTRA_PROPERTIES:-}\"\
-            && export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"cluster-client-media-driver\"\
+            && export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"cluster-client-media-driver\" OUTPUT_DIR=\"${output_dir}\"\
             ; $(kill_java_process "${client_class_name}")\
             ; ${client_driver}\
             && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/${client_script} & \

--- a/scripts/aeron/remote-echo-benchmarks
+++ b/scripts/aeron/remote-echo-benchmarks
@@ -287,7 +287,7 @@ do
     server_class_name="io.aeron.benchmarks.aeron.EchoNode"
 
     start_client="\
-    export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"echo-client-media-driver\" \
+    export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"echo-client-media-driver\" OUTPUT_DIR=\"${output_dir}\"\
     ; $(kill_java_process "${client_class_name}") \
     ; ${client_driver} \
     && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/echo-client & \
@@ -296,7 +296,7 @@ do
     && tail --pid=\$! -f /dev/null; kill -SIGTERM \${media_driver_pid}; wait"
 
     start_server="\
-    export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"echo-server-media-driver\"\
+    export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"echo-server-media-driver\" OUTPUT_DIR=\"${output_dir}\"\
     && ${server_driver} \
     && numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} --physcpubind=\"${SERVER_NON_ISOLATED_CPU_CORES}\" ${SERVER_BENCHMARKS_PATH}/scripts/aeron/echo-server & \
     $(await_java_process_start "${server_class_name}") \

--- a/scripts/aeron/remote-echo-mdc-benchmarks
+++ b/scripts/aeron/remote-echo-mdc-benchmarks
@@ -208,7 +208,7 @@ function start_node()
   local destination_channel_var=NODE${node_id}_DESTINATION_CHANNEL
   local source_channel_var=NODE${node_id}_SOURCE_CHANNEL
   echo "
-    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"echo-node-media-driver-${node_id}\" \
+    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"echo-node-media-driver-${node_id}\" OUTPUT_DIR=\"${output_dir}\"\
     ; $(kill_java_process "${node_class_name}") \
     ; ${server_driver} \
     && export JVM_OPTS=\"\
@@ -217,7 +217,7 @@ function start_node()
     -Dio.aeron.benchmarks.aeron.destination.channel=${!destination_channel_var} \
     -Dio.aeron.benchmarks.aeron.source.channel=${!source_channel_var} \
     -Dio.aeron.benchmarks.aeron.receiver.index=${node_id} \
-    ${!extra_properties_var:-}\" PROCESS_FILE_NAME=\"echo-node-${node_id}\" \
+    ${!extra_properties_var:-}\" PROCESS_FILE_NAME=\"echo-node-${node_id}\" OUTPUT_DIR=\"${output_dir}\"\
     && numactl --membind=${!cpu_node_var} --cpunodebind=${!cpu_node_var} --physcpubind=\"${!non_isolated_cpu_cores_var}\" ${!benchmarks_path_var}/scripts/aeron/echo-server & \
     $(await_java_process_start "${node_class_name}") \
     ; $(pin_thread "\${pid}" "echo-${node_id}" "${!echo_cpu_var}") \
@@ -387,7 +387,7 @@ do
           -Dio.aeron.benchmarks.aeron.source.channel=${CLIENT_SOURCE_CHANNEL}\
           -Dio.aeron.benchmarks.aeron.receiver.count=${RECEIVER_COUNT}\
           ${CLIENT_EXTRA_PROPERTIES:-}\"\
-          && export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"client-media-driver\"\
+          && export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"client-media-driver\" OUTPUT_DIR=\"${output_dir}\"\
           ; $(kill_java_process "${client_class_name}")\
           ; ${client_driver}\
           && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/echo-client & \

--- a/scripts/aeron/remote-echo-single-host-benchmarks
+++ b/scripts/aeron/remote-echo-single-host-benchmarks
@@ -184,7 +184,7 @@ function start_node()
   local destination_channel_var=NODE${node_id}_DESTINATION_CHANNEL
   local source_channel_var=NODE${node_id}_SOURCE_CHANNEL
   echo "
-    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"echo-node-media-driver-${node_id}\" \
+    export JAVA_HOME=\"${!java_home_var}\" PROCESS_FILE_NAME=\"echo-node-media-driver-${node_id}\" OUTPUT_DIR=\"${output_dir}\"\
     ; $(kill_java_process "${server_class_name}") \
     ; ${server_driver} \
     && export JVM_OPTS=\"\
@@ -193,7 +193,7 @@ function start_node()
     -Dio.aeron.benchmarks.aeron.destination.channel=${!destination_channel_var} \
     -Dio.aeron.benchmarks.aeron.source.channel=${!source_channel_var} \
     -Dio.aeron.benchmarks.aeron.receiver.index=${node_id} \
-    ${!extra_properties_var:-}\" PROCESS_FILE_NAME=\"echo-node-${node_id}\" \
+    ${!extra_properties_var:-}\" PROCESS_FILE_NAME=\"echo-node-${node_id}\" OUTPUT_DIR=\"${output_dir}\"\
     && numactl --membind=${!cpu_node_var} --cpunodebind=${!cpu_node_var} --physcpubind=\"${!non_isolated_cpu_cores_var}\" ${!benchmarks_path_var}/scripts/aeron/echo-server & \
     $(await_java_process_start "${server_class_name}") \
     ; $(pin_thread "\${pid}" "echo-${node_id}" "${!echo_cpu_var}") \
@@ -347,6 +347,7 @@ do
           -Dio.aeron.benchmarks.aeron.destination.channel=${DESTINATION_CHANNEL}\
           -Dio.aeron.benchmarks.aeron.source.channel=${SOURCE_CHANNEL}\"\
           && export JAVA_HOME=\"${JAVA_HOME}\"\
+          && OUTPUT_DIR=\"${output_dir}\"\
           ; $(kill_java_process "${client_class_name}")\
           ; $(kill_java_process "${server_class_name}")\
           ; ${media_driver}\

--- a/scripts/aeron/remote-live-recording-benchmarks
+++ b/scripts/aeron/remote-live-recording-benchmarks
@@ -265,7 +265,7 @@ do
       fi
 
       start_client="\
-      export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"live-recording-client-media-driver\"\
+      export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"live-recording-client-media-driver\" OUTPUT_DIR=\"${output_dir}\"\
       ; $(kill_java_process "${client_class_name}") \
       ; rm -rf ${ARCHIVE_DIR} \
       ; sync; echo 3 | sudo tee /proc/sys/vm/drop_caches; fstrim --all \
@@ -279,7 +279,7 @@ do
       && tail --pid=\$! -f /dev/null && kill -SIGTERM \${media_driver_pid}; wait"
 
       start_server="\
-      export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"echo-node-media-driver\"\
+      export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"echo-node-media-driver\" OUTPUT_DIR=\"${output_dir}\"\
       ; $(kill_java_process "${server_class_name}") \
       ; ${server_driver} \
       && numactl --membind=${SERVER_CPU_NODE} --cpunodebind=${SERVER_CPU_NODE} --physcpubind=\"${SERVER_NON_ISOLATED_CPU_CORES}\" ${SERVER_BENCHMARKS_PATH}/scripts/aeron/echo-server & \

--- a/scripts/aeron/remote-live-replay-benchmarks
+++ b/scripts/aeron/remote-live-replay-benchmarks
@@ -265,7 +265,7 @@ do
       fi
 
       start_client="\
-      export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"live-replay-client-media-driver\"\
+      export JAVA_HOME=\"${CLIENT_JAVA_HOME}\" PROCESS_FILE_NAME=\"live-replay-client-media-driver\" OUTPUT_DIR=\"${output_dir}\"\
       ; $(kill_java_process "${client_class_name}") \
       ; ${client_driver} \
       && numactl --membind=${CLIENT_CPU_NODE} --cpunodebind=${CLIENT_CPU_NODE} --physcpubind=\"${CLIENT_NON_ISOLATED_CPU_CORES}\" ${CLIENT_BENCHMARKS_PATH}/scripts/aeron/live-replay-client & \
@@ -274,7 +274,7 @@ do
       && tail --pid=\$! -f /dev/null && kill -SIGTERM \${media_driver_pid}; wait"
 
       start_server="\
-      export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"archive-node-media-driver\" \
+      export JAVA_HOME=\"${SERVER_JAVA_HOME}\" PROCESS_FILE_NAME=\"archive-node-media-driver\" OUTPUT_DIR=\"${output_dir}\"\
       ; $(kill_java_process "${server_class_name}") \
       ; rm -rf ${ARCHIVE_DIR} \
       ; sync; echo 3 | sudo tee /proc/sys/vm/drop_caches; fstrim --all \


### PR DESCRIPTION
Added the OUTPUT_DIR variable to all scripts so that on the 'remote' side, every script knows the directory it can output to.

This is useful when overriding scripts in running with e.g. async-profilers so that the jfr files can be placed in the $OUTPUT_DIR and automatically be downloaded.