### PR TITLE
Fix remote-echo-single-host-benchmarks OUTPUT_DIR

### DIFF
--- a/scripts/aeron/remote-echo-single-host-benchmarks
+++ b/scripts/aeron/remote-echo-single-host-benchmarks
@@ -347,7 +347,7 @@ do
           -Dio.aeron.benchmarks.aeron.destination.channel=${DESTINATION_CHANNEL}\
           -Dio.aeron.benchmarks.aeron.source.channel=${SOURCE_CHANNEL}\"\
           && export JAVA_HOME=\"${JAVA_HOME}\"\
-          && OUTPUT_DIR=\"${output_dir}\"\
+          && OUTPUT_DIR=\"${BENCHMARKS_PATH}/${output_dir}\"\
           ; $(kill_java_process "${client_class_name}")\
           ; $(kill_java_process "${server_class_name}")\
           ; ${media_driver}\


### PR DESCRIPTION
The OUTPUT_DIR didn't contain the full path.